### PR TITLE
Attempt at opening up integer instructions to other types

### DIFF
--- a/muggl-core/src/de/wwu/muggl/instructions/general/Load.java
+++ b/muggl-core/src/de/wwu/muggl/instructions/general/Load.java
@@ -93,7 +93,7 @@ public abstract class Load extends GeneralInstructionWithOtherBytes implements L
 			if (localVariables[localVariable] != null && !this.typedInstruction.checkDesiredType(localVariables[localVariable].getClass().getName()))
 				throw new ExecutionException("Could not load local variable #" + localVariable + ": Expected " + this.typedInstruction.getDesiredType() + ", got " + localVariables[localVariable].getClass() + ".");
 
-			frame.getOperandStack().push(localVariables[localVariable]);
+			frame.getOperandStack().push(typedInstruction.validateAndExtendValue(localVariables[localVariable]));
 		} catch (ExecutionException e) {
 			executionFailed(e);
 		}

--- a/muggl-core/src/de/wwu/muggl/instructions/typed/IntegerInstruction.java
+++ b/muggl-core/src/de/wwu/muggl/instructions/typed/IntegerInstruction.java
@@ -40,7 +40,7 @@ public class IntegerInstruction extends TypedInstruction {
 	 * for java.lang.Byte, .Short, and .Char use sign-extension.
 	 * @param value The object that needs to be extended.
 	 * @param type The type of the object, which determines the extension strategy.
-	 * @return The extended value.
+	 * @return The value, extended to Integer.
 	 */
 	@Override
 	protected Object extendValue(Object value, String type) {
@@ -63,7 +63,7 @@ public class IntegerInstruction extends TypedInstruction {
 	 * truncated to a byte, short, char, or boolean.
 	 * @param value The object that needs to be truncated.
 	 * @param type The type of the object, which determines the truncation strategy.
-	 * @return The truncated value.
+	 * @return The value, truncated to the type indicated by `type'.
 	 */
 	@Override
 	protected Object truncateValue(Object value, String type) {

--- a/muggl-core/src/de/wwu/muggl/instructions/typed/TypedInstruction.java
+++ b/muggl-core/src/de/wwu/muggl/instructions/typed/TypedInstruction.java
@@ -80,7 +80,7 @@ public abstract class TypedInstruction {
 	 * Validate the value and extend if it necessary.
 	 *
 	 * @param value The (probably extended) value to check.
-	 * @return true, if value is of one of the desired types, false otherwise.
+	 * @return an object containing the extended value if there is an applicable type.
 	 * @throws ExecutionException If the supplied value does not match the expected type, an
 	 *         ExecutionException is thrown.
 	 */

--- a/muggl-core/src/de/wwu/muggl/vm/execution/MugglToJavaConversion.java
+++ b/muggl-core/src/de/wwu/muggl/vm/execution/MugglToJavaConversion.java
@@ -796,6 +796,10 @@ public class MugglToJavaConversion {
 							} else {
 								toInsert = toJava(toInsert);
 							}
+							
+							if (toInsert instanceof java.lang.Integer) {
+								toInsert = truncateInteger(toInsert, objectField.getType());
+							}
 
 							// Ensure accessibility.
 							objectField.setAccessible(true);
@@ -826,6 +830,27 @@ public class MugglToJavaConversion {
 				// Not found the field?
 				if (!insertedSuccessfully) throw new NoSuchFieldException(field.getName());
 			}
+		}
+	}
+
+	private Object truncateInteger(Object value, Class<?> type) {
+		// null stays null
+		if (value == null) {
+			return null;
+		}
+		
+		// Change representation of integer values, if applicable
+		switch (type.getName()) {
+		case "java.lang.Boolean": case "boolean":
+			return ((Integer) value).intValue() == 1 ? Boolean.TRUE : Boolean.FALSE;
+		case "java.lang.Byte": case "byte":
+			return ((Integer) value).byteValue();
+		case "java.lang.Short": case "short":
+			return ((Integer) value).shortValue();
+		case "java.lang.Character": case "char":
+			return (char) ((Integer) value).intValue();
+		default: 
+			return value;
 		}
 	}
 


### PR DESCRIPTION
Make integer instructions (especially iload, iload_n) open to integer-compatible types, i.e. bool, char, byte, short (and int).
This attempts to fix #41. @kralo, please try reproducing your example.
